### PR TITLE
feat(button): added new alternative button variant

### DIFF
--- a/packages/Button/Button.jsx
+++ b/packages/Button/Button.jsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react'
 import PropTypes from 'prop-types'
 import { css } from '@emotion/core'
-import { parkGreen, lightTan, lilyGreen } from '@pm-kit/colours'
+import { parkGreen, lightTan, lilyGreen, white, softSandBrown } from '@pm-kit/colours'
 
 const base = css`
   display: block;
@@ -23,7 +23,7 @@ const base = css`
 `
 
 const primary = css`
-  color: white;
+  color: ${white};
   background-color: ${parkGreen};
   &:hover {
     background-color: ${lilyGreen};
@@ -57,6 +57,17 @@ const inverted = css`
     background-color: ${lightTan};
   }
 `
+const alternative = css`
+  color: ${white};
+  background-color: ${parkGreen};
+  &:hover {
+    background-color: ${softSandBrown};
+    color: ${parkGreen};
+  }
+  &:active {
+    background-color: ${softSandBrown};
+  }
+`
 
 const disabledStyle = css`
   opacity: 0.5;
@@ -74,6 +85,9 @@ export const Button = ({ children, type, variant, wide, disabled, forwardedRef, 
       break
     case 'inverted':
       variantStyles = inverted
+      break
+    case 'alternative':
+      variantStyles = alternative
       break
     default:
       variantStyles = primary
@@ -103,7 +117,7 @@ Button.propTypes = {
   /**
    * The style.
    */
-  variant: PropTypes.oneOf(['primary', 'secondary', 'inverted']),
+  variant: PropTypes.oneOf(['primary', 'secondary', 'inverted', 'alternative']),
   /**
    * The label. It can include the `A11yContent` component or strings.
    */

--- a/packages/Button/Button.stories.js
+++ b/packages/Button/Button.stories.js
@@ -33,9 +33,15 @@ export const Disabled = () => (
   </Button>
 )
 
+export const Alternative = () => (
+  <Button variant="alternative" onClick={action('clicked')}>
+    Alternative Button
+  </Button>
+)
+
 export const Playground = () => (
   <Button
-    variant={select('Variant', ['primary', 'secondary', 'inverted'])}
+    variant={select('Variant', ['primary', 'secondary', 'inverted', 'alternative'])}
     disabled={boolean('Disabled', false)}
     onClick={action('clicked')}
   >

--- a/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
+++ b/packages/Button/__tests__/__snapshots__/Button.spec.jsx.snap
@@ -17,7 +17,7 @@ exports[`Button renders 1`] = `
   cursor: pointer;
   -webkit-transition: background-color 0.2s,color 0.2s;
   transition: background-color 0.2s,color 0.2s;
-  color: white;
+  color: #FFF;
   background-color: #034045;
 }
 


### PR DESCRIPTION
Updated PM-Kit button component with a new 'alternative' button variant style to fit 'lilyGreen' background

## Checklist before submitting pull request

- [x] New code is unit tested
- [x] For packages, its Storybook story is up to date with latest changes
