### PR TITLE
feat(input): added an option to allow unmasking of password or not

### DIFF
--- a/packages/Input/Input.jsx
+++ b/packages/Input/Input.jsx
@@ -86,11 +86,6 @@ const largeLabelContainer = css`
   margin: 0 0 0.5rem 0.2rem;
 `
 
-const mobileLabelContainer = css`
-  ${labelContainer}
-  font-size: ${size.bodyMedium};
-`
-
 const isDisabled = css`
   opacity: 0.5;
 `
@@ -147,9 +142,6 @@ export const Input = ({
 
   if (labelType === 'large') {
     labelContainerArr.push(largeLabelContainer)
-  }
-  if (labelType === 'mobile') {
-    labelContainerArr.push(mobileLabelContainer)
   }
 
   if (feedback === 'error') {
@@ -300,7 +292,7 @@ Input.propTypes = {
   /**
    * The type of label to display.
    */
-  labelType: PropTypes.oneOf(['large', 'mobile', 'small', 'hidden']),
+  labelType: PropTypes.oneOf(['large', 'small', 'hidden']),
   /**
    * Use `value` for controlled Inputs. For uncontrolled Inputs, use React's built-in `defaultValue` prop.
    * For input of type `password`, value is required.

--- a/packages/Input/Input.jsx
+++ b/packages/Input/Input.jsx
@@ -129,6 +129,7 @@ export const Input = ({
   error,
   feedbackicon,
   type,
+  canUnmaskPassword,
   styles,
   forwardedRef,
   ...rest
@@ -227,16 +228,18 @@ export const Input = ({
               id={inputId.identity()}
               name={name}
               onKeyDown={handleKeyDown}
-              type={display ? 'text' : 'password'}
+              type={canUnmaskPassword && display ? 'text' : 'password'}
               value={value}
               onChange={onChange}
               disabled={disabled}
               ref={forwardedRef}
               {...rest}
             />
-            <button css={eyeButtonArr} onClick={showPassword}>
-              <img css={eyeImage} src={display ? hide : show} alt="show password" />
-            </button>
+            {canUnmaskPassword && (
+              <button css={eyeButtonArr} onClick={showPassword}>
+                <img css={eyeImage} src={display ? hide : show} alt="show password" />
+              </button>
+            )}
           </div>
         ) : (
           <input
@@ -312,6 +315,10 @@ Input.propTypes = {
    */
   type: PropTypes.oneOf(['text', 'number', 'password', 'email', 'search', 'tel', 'url']),
   /**
+   * Controls whether the option of unmask password be given or not.
+   */
+  canUnmaskPassword: PropTypes.bool,
+  /**
    * Customizes the input according to your needs.
    * Accepts an object of styles in the structure below.
    * {
@@ -336,6 +343,7 @@ Input.defaultProps = {
   labelType: 'small',
   type: 'text',
   forwardedRef: undefined,
+  canUnmaskPassword: true,
   styles: {},
 }
 

--- a/packages/Input/Input.jsx
+++ b/packages/Input/Input.jsx
@@ -129,7 +129,7 @@ export const Input = ({
   error,
   feedbackicon,
   type,
-  canUnmaskPassword,
+  disableUnmasking,
   styles,
   forwardedRef,
   ...rest
@@ -228,14 +228,14 @@ export const Input = ({
               id={inputId.identity()}
               name={name}
               onKeyDown={handleKeyDown}
-              type={canUnmaskPassword && display ? 'text' : 'password'}
+              type={!disableUnmasking && display ? 'text' : 'password'}
               value={value}
               onChange={onChange}
               disabled={disabled}
               ref={forwardedRef}
               {...rest}
             />
-            {canUnmaskPassword && (
+            {!disableUnmasking && (
               <button css={eyeButtonArr} onClick={showPassword}>
                 <img css={eyeImage} src={display ? hide : show} alt="show password" />
               </button>
@@ -317,7 +317,7 @@ Input.propTypes = {
   /**
    * Controls whether the option of unmask password be given or not.
    */
-  canUnmaskPassword: PropTypes.bool,
+  disableUnmasking: PropTypes.bool,
   /**
    * Customizes the input according to your needs.
    * Accepts an object of styles in the structure below.
@@ -343,7 +343,7 @@ Input.defaultProps = {
   labelType: 'small',
   type: 'text',
   forwardedRef: undefined,
-  canUnmaskPassword: true,
+  disableUnmasking: false,
   styles: {},
 }
 

--- a/packages/Input/Input.stories.js
+++ b/packages/Input/Input.stories.js
@@ -63,6 +63,7 @@ export const Playground = () => {
       disabled={boolean('Disable Input', false)}
       type={select('Type', ['text', 'password'])}
       labelType={select('Label Type', ['large', 'mobile', 'small', 'hidden'], 'small')}
+      canUnmaskPassword={boolean('Can unmask Password', true)}
       styles={object('Styles', {
         inputWrapperStyle: {},
         inputStyle: {},

--- a/packages/Input/Input.stories.js
+++ b/packages/Input/Input.stories.js
@@ -63,7 +63,7 @@ export const Playground = () => {
       disabled={boolean('Disable Input', false)}
       type={select('Type', ['text', 'password'])}
       labelType={select('Label Type', ['large', 'mobile', 'small', 'hidden'], 'small')}
-      canUnmaskPassword={boolean('Can unmask Password', true)}
+      disableUnmasking={boolean('Disable unmasking Password', false)}
       styles={object('Styles', {
         inputWrapperStyle: {},
         inputStyle: {},

--- a/packages/Input/Input.stories.js
+++ b/packages/Input/Input.stories.js
@@ -16,8 +16,6 @@ export const Default = () => <Input placeholder="Placeholder" label="Label" />
 
 export const LargeLabel = () => <Input placeholder="Placeholder" label="Label" labelType="large" />
 
-export const MobileLabel = () => <Input placeholder="Placeholder" label="Label" labelType="mobile" />
-
 export const NoLabel = () => <Input placeholder="Placeholder" label="Label" labelType="hidden" />
 
 export const Error = () => <Input placeholder="Placeholder" label="Label" feedback="error" error="error" />
@@ -62,7 +60,7 @@ export const Playground = () => {
       required={boolean('Required Input', false)}
       disabled={boolean('Disable Input', false)}
       type={select('Type', ['text', 'password'])}
-      labelType={select('Label Type', ['large', 'mobile', 'small', 'hidden'], 'small')}
+      labelType={select('Label Type', ['large', 'small', 'hidden'], 'small')}
       disableUnmasking={boolean('Disable unmasking Password', false)}
       styles={object('Styles', {
         inputWrapperStyle: {},


### PR DESCRIPTION
Added a prop called canUnmaskPassword which gives the control to give user the option of viewing their password or not. Its default value is true which allows the user to view their password entered (unmask it). If you set it to false, the user cannot unmask their password.

## Checklist before submitting pull request

- [ ] New code is unit tested
- [ ] For packages, its Storybook story is up to date with latest changes
