### PR TITLE
chore(card): moved focus to parent to include placeholder

### DIFF
--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -203,14 +203,12 @@ const Card = ({ expandable, placeholder, title, subtitle, children, onClick, isS
     <motion.div css={cardStyles} variants={planVariant}>
       <div css={cardContainerDetails}>
         <div css={selectOptionContainerStyles} onClick={selectable ? onCardClick : undefined}>
-          <div css={cardRowContainer}>
+          <div css={cardRowContainer} tabIndex="0">
             <div>{placeholder && placeholder}</div>
-            <div tabIndex="0">
-              <Paragraph css={titleStyle} size={paragraphLargeSizeStyle}>
-                {title}
-              </Paragraph>
-              <p css={paddingLeft}>{subtitle}</p>
-            </div>
+            <Paragraph css={titleStyle} size={paragraphLargeSizeStyle}>
+              {title}
+            </Paragraph>
+            <p css={paddingLeft}>{subtitle}</p>
           </div>
           {selectable && (
             <div css={selectOption}>

--- a/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
+++ b/packages/Card/__tests__/__snapshots__/Card.spec.jsx.snap
@@ -103,22 +103,19 @@ exports[`Card renders 1`] = `
     >
       <div
         class="emotion-2"
+        tabindex="0"
       >
         <div />
-        <div
-          tabindex="0"
+        <p
+          class="emotion-0"
         >
-          <p
-            class="emotion-0"
-          >
-            title
-          </p>
-          <p
-            class="emotion-1"
-          >
-            subtitle
-          </p>
-        </div>
+          title
+        </p>
+        <p
+          class="emotion-1"
+        >
+          subtitle
+        </p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
On Tab to the card, the title and placeholder should be focused on and not only title.

## Checklist before submitting pull request

- [ ] New code is unit tested
- [ ] For packages, its Storybook story is up to date with latest changes
