### PR TITLE
fix(card): enable reading details before moving to button (a11y)

### DIFF
--- a/packages/Card/Card.jsx
+++ b/packages/Card/Card.jsx
@@ -4,11 +4,12 @@ import { css } from '@emotion/core'
 import { motion, AnimatePresence } from 'framer-motion'
 import { offWhite, parkGreen, lilyGreen } from '@pm-kit/colours'
 import { weight } from '@pm-kit/typography'
+import Paragraph from '@pm-kit/paragraph'
+
 import downArrow from '../../shared/svg/arrow-show.svg'
 import upArrow from '../../shared/svg/arrow-hide.svg'
 import checkmark from '../../shared/png/Checkmark/verified@3x.png'
 import oval from '../../shared/png/EmptyOval/oval@3x.png'
-import Paragraph from '@pm-kit/paragraph'
 
 const card = css`
   width: 100%;
@@ -51,6 +52,9 @@ const line = css`
   border-bottom-width: 1px;
   margin-left: 35px;
   margin-right: 35px;
+  &:focus {
+    outline: none;
+  }
 `
 
 const detailsBar = css`
@@ -232,8 +236,8 @@ const Card = ({ expandable, placeholder, title, subtitle, children, onClick, isS
           )}
         </div>
         {children && (
-          <div ref={detailsRef} tabIndex="-1">
-            <div css={line}></div>
+          <>
+            <div css={line} ref={detailsRef} tabIndex="-1" />
             <AnimatePresence>
               {openCard && (
                 <motion.div
@@ -246,7 +250,7 @@ const Card = ({ expandable, placeholder, title, subtitle, children, onClick, isS
                 </motion.div>
               )}
             </AnimatePresence>
-          </div>
+          </>
         )}
         {expandable && (
           <button name="details" type="button" css={detailsBarStyles} onClick={toggleOpenCard}>

--- a/packages/Card/Card.stories.js
+++ b/packages/Card/Card.stories.js
@@ -82,7 +82,16 @@ export const MultipleCards = () => {
           onClick={() => setSelectedCard(idCard1)}
           expandable={{ details: 'Details', collapse: 'Collapse' }}
         >
-          <p>Card 1</p>
+          <>
+            <p>Details for card1</p>
+            <ul>
+              <li>Detail 1</li>
+              <li>Detail 2</li>
+              <li>Detail 3</li>
+              <li>Detail 4</li>
+              <li>Detail 5</li>
+            </ul>
+          </>
         </Card>
       </div>
       <div style={{ width: '40%' }}>
@@ -93,7 +102,16 @@ export const MultipleCards = () => {
           onClick={() => setSelectedCard(idCard2)}
           expandable={{ details: 'Details', collapse: 'Collapse' }}
         >
-          <p>Card 2</p>
+          <>
+            <p>Details for card2</p>
+            <ul>
+              <li>Detail 1</li>
+              <li>Detail 2</li>
+              <li>Detail 3</li>
+              <li>Detail 4</li>
+              <li>Detail 5</li>
+            </ul>
+          </>
         </Card>
       </div>
     </div>

--- a/packages/Dropdown/package-lock.json
+++ b/packages/Dropdown/package-lock.json
@@ -36,17 +36,17 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+			"integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/types": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+			"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
 				"lodash": "^4.17.13",
@@ -366,9 +366,9 @@
 					}
 				},
 				"tslib": {
-					"version": "1.11.1",
-					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
-					"integrity": "sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA=="
+					"version": "1.11.2",
+					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.2.tgz",
+					"integrity": "sha512-tTSkux6IGPnUGUd1XAZHcpu85MOkIl5zX49pO+jfsie3eP0B6pyhOlLXm3cAC6T7s+euSDDUUV+Acop5WmtkVg=="
 				}
 			}
 		},
@@ -497,9 +497,9 @@
 			}
 		},
 		"react-transition-group": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.3.0.tgz",
-			"integrity": "sha512-1qRV1ZuVSdxPlPf4O8t7inxUGpdyO5zG9IoNfJxSO0ImU2A1YWkEQvFPuIPZmMLkg5hYs7vv5mMOyfgSkvAwvw==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
+			"integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"dom-helpers": "^5.0.1",


### PR DESCRIPTION
Bug: Even after setting the focus on details section, the user was unable to access the details text on pressing ctrl+option+right arrow. Instead, the focus moved to collapse button.

After implementing the fix, on clicking details button it focuses on details group and the user can access the details text using ctrl+option+right arrow.

## Checklist before submitting pull request

- [ ] New code is unit tested
- [ ] For packages, its Storybook story is up to date with latest changes
