### PR TITLE
feat(dropdown): added a loading state

### DIFF
--- a/packages/Dropdown/Dropdown.jsx
+++ b/packages/Dropdown/Dropdown.jsx
@@ -5,6 +5,7 @@ import Select, { components, createFilter } from 'react-select'
 import { motion, AnimatePresence } from 'framer-motion'
 import { size, weight } from '@pm-kit/typography'
 import { parkGreen, red, lightTan, white } from '@pm-kit/colours'
+import FeedbackIcon from '@pm-kit/feedback-icon'
 import generateId from '../../shared/utils/generateId/generateId.js'
 
 const dropdownWrapper = css`
@@ -68,6 +69,7 @@ export const Dropdown = ({
   required,
   type,
   value,
+  loadingState,
   placeholder,
   ignoreCase,
   ignoreAccents,
@@ -163,6 +165,14 @@ export const Dropdown = ({
     return <components.Input {...props} maxLength={searchMaxLength} />
   }
 
+  const DropdownIndicator = props => {
+    return (
+      <components.DropdownIndicator {...props}>
+        {loadingState !== 'success' && <FeedbackIcon state={loadingState} />}
+      </components.DropdownIndicator>
+    )
+  }
+
   return (
     <div css={dropdownWrapperArr}>
       {labelType !== 'hidden' && (
@@ -182,7 +192,7 @@ export const Dropdown = ({
         styles={customDropdownStyles}
         isClearable={true}
         clearIndicator={false}
-        components={{ Menu, Option, SelectContainer, Placeholder, Input }}
+        components={{ Menu, Option, SelectContainer, Placeholder, Input, DropdownIndicator }}
         filterOption={createFilter(filterConfig)}
         ref={forwardedRef}
         {...rest}
@@ -308,6 +318,10 @@ Dropdown.propTypes = {
    * }
    */
   styles: PropTypes.object,
+  /**
+   * Replaces chevron with a feedback icon based on loading state of options.
+   */
+  loadingState: PropTypes.oneOf(['waiting', 'success', 'error']),
 }
 
 Dropdown.defaultProps = {
@@ -325,6 +339,7 @@ Dropdown.defaultProps = {
   labelType: 'small',
   searchMaxLength: 100,
   styles: {},
+  loadingState: 'success',
 }
 
 const DropdownWithRef = forwardRef((props, ref) => <Dropdown {...props} forwardedRef={ref} />)

--- a/packages/Dropdown/Dropdown.stories.js
+++ b/packages/Dropdown/Dropdown.stories.js
@@ -97,6 +97,7 @@ export const Playground = () => {
       ignoreCase={select('ignore case', [true, false], true)}
       labelType={select('label type', ['hidden', 'large', 'small'], 'small')}
       searchMaxLength={number('max length')}
+      loadingState={select('loading state', ['success', 'waiting', 'error'], 'success')}
       styles={object('Styles', {
         dropdownStyle: {},
         labelStyle: {},

--- a/packages/Dropdown/package-lock.json
+++ b/packages/Dropdown/package-lock.json
@@ -139,6 +139,15 @@
 			"resolved": "https://registry.npmjs.org/@pm-kit/colours/-/colours-1.1.0.tgz",
 			"integrity": "sha512-LPAe/sxKbNc1+eDtcgpc6Mq/dUsTS4tJd3YkJylghzbYMcJN78871hmc3PmVMhx7IU2oZ/Tvv4xGaJE2pM0iIA=="
 		},
+		"@pm-kit/feedback-icon": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@pm-kit/feedback-icon/-/feedback-icon-2.0.1.tgz",
+			"integrity": "sha512-TipRawe9MqQokCFkyU7wFKF3+Mg340iPc//pRfzZKTWvgCuKuodfkw6vYkQOLHVwsak5HQWGRMyPqcJmMcAxpw==",
+			"requires": {
+				"@pm-kit/colours": "^1.1.0",
+				"prop-types": "^15.7.2"
+			}
+		},
 		"@pm-kit/typography": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/@pm-kit/typography/-/typography-1.0.0.tgz",

--- a/packages/Dropdown/package.json
+++ b/packages/Dropdown/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "@pm-kit/colours": "^1.1.0",
+    "@pm-kit/feedback-icon": "^2.0.1",
     "@pm-kit/typography": "^1.0.0",
     "framer-motion": "^1.8.3",
     "prop-types": "^15.7.2",


### PR DESCRIPTION
Added a loading state to dropdown. It replaces the chevron with with a feedback icon based on the loading state passed. If the loadingState is "waiting" it shows a spinner. If the loading state is error it shows an error icon.

## Checklist before submitting pull request

- [ ] New code is unit tested
- [ ] For packages, its Storybook story is up to date with latest changes
